### PR TITLE
Update note.json

### DIFF
--- a/2BFAUAD4F/note.json
+++ b/2BFAUAD4F/note.json
@@ -274,7 +274,7 @@
     }
   ],
   "name":"hdfs-d3",
-  "id":"2BHU1G67J",
+  "id":"2BFAUAD4F",
   "owners":[
 
   ],


### PR DESCRIPTION
The notebook's ID is wrong!
Please replace "2BHU1G67J" with "2BFAUAD4F"

The code causes the following problems:
ERROR [2016-06-26 20:06:24,336]({main} Notebook.java[loadNoteFromRepo]:330) - Failed to load 2BHU1G67J
java.io.IOException: file:///usr/hdp/current/zeppelin-server/lib/notebook/2BHU1G67J is not a directory
