### PR TITLE
Update update_all_notebooks.sh

### DIFF
--- a/update_all_notebooks.sh
+++ b/update_all_notebooks.sh
@@ -1,4 +1,4 @@
-cd /usr/hdp/current/zeppelin-server/lib/notebook
+cd /usr/hdp/current/zeppelin-server/notebook
 OLD_DIR=`date +%Y%m%d-%H%M%S`
 mkdir old_${OLD_DIR}
 mv 2* old_${OLD_DIR}/


### PR DESCRIPTION
- updated path to zeppelin notebook
- path changed in hdp 2.5 sandbox

Sandbox-version

Sandbox information:
Created on: 24_06_2016_00_31_56 for
Hadoop stack version:  Hadoop 2.7.1.2.5.0.0-817
Ambari Version: 2.4.0.0-685
Ambari Hash: 9b70e50de85eeff18184d2158b6d03a5657751f6
Ambari build:  Release : 685
Java version:  1.7.0_101
OS Version:  CentOS release 6.8 (Final)
